### PR TITLE
Add CopperPower Fabric mod project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/.gradle/
+/.idea/
+*.iml
+/run/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 CopperPower
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'fabric-loom' version '1.6'
+    id 'maven-publish'
+}
+
+group = project.properties['maven_group']
+version = project.properties['mod_version']
+
+base {
+    archivesName = project.properties['archives_base_name']
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        name = 'Fabric'
+        url = 'https://maven.fabricmc.net/'
+    }
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:${project.properties['minecraft_version']}"
+    mappings "net.fabricmc:yarn:${project.properties['yarn_mappings']}:v2"
+    modImplementation "net.fabricmc:fabric-loader:${project.properties['loader_version']}"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.properties['fabric_version']}"
+}
+
+loom {
+    splitEnvironmentSourceSets()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+    withSourcesJar()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release = 17
+}
+
+jar {
+    from('LICENSE') {
+        rename { String name -> "${name}_${project.properties['archives_base_name']}" }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.jvmargs=-Xmx2G
+minecraft_version=1.20.1
+loader_version=0.15.11
+fabric_version=0.92.2+1.20.1
+yarn_mappings=1.20.1+build.10
+mod_version=1.0.0
+maven_group=com.example
+archives_base_name=CopperPower

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        maven {
+            name = "Fabric"
+            url = "https://maven.fabricmc.net/"
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "CopperPower"

--- a/src/main/java/com/example/copperpower/CopperNetwork.java
+++ b/src/main/java/com/example/copperpower/CopperNetwork.java
@@ -1,0 +1,127 @@
+package com.example.copperpower;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Oxidizable;
+import net.minecraft.registry.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.WorldView;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public final class CopperNetwork {
+    private static final Direction[] DIRECTIONS = Direction.values();
+
+    private CopperNetwork() {
+    }
+
+    public static boolean isConductiveCopper(BlockState state) {
+        return state != null && state.isIn(BlockTags.COPPER_BLOCKS);
+    }
+
+    public static int computePower(BlockState state, net.minecraft.world.BlockView world, BlockPos pos) {
+        if (!isConductiveCopper(state)) {
+            return 0;
+        }
+
+        if (!(world instanceof WorldAccess worldAccess)) {
+            return 0;
+        }
+
+        Set<BlockPos> component = collectComponent(worldAccess, pos);
+        if (component.isEmpty()) {
+            return 0;
+        }
+
+        Map<BlockPos, Integer> insidePower = new HashMap<>();
+        Deque<BlockPos> queue = new ArrayDeque<>();
+
+        // Seed from external redstone sources touching the network
+        for (BlockPos copperPos : component) {
+            int best = insidePower.getOrDefault(copperPos, 0);
+            for (Direction direction : DIRECTIONS) {
+                BlockPos neighborPos = copperPos.offset(direction);
+                if (component.contains(neighborPos)) {
+                    continue;
+                }
+                int neighborPower = MathHelper.clamp(worldAccess.getEmittedRedstonePower(neighborPos, direction.getOpposite()), 0, 15);
+                if (neighborPower > best) {
+                    best = neighborPower;
+                }
+            }
+            if (best > 0) {
+                insidePower.put(copperPos, best);
+                queue.addLast(copperPos);
+            } else {
+                insidePower.putIfAbsent(copperPos, 0);
+            }
+        }
+
+        while (!queue.isEmpty()) {
+            BlockPos current = queue.removeFirst();
+            BlockState currentState = worldAccess.getBlockState(current);
+            int inside = insidePower.getOrDefault(current, 0);
+            int output = MathHelper.clamp(inside - getPenalty(currentState), 0, 15);
+            if (output <= 0) {
+                continue;
+            }
+            for (Direction direction : DIRECTIONS) {
+                BlockPos neighbor = current.offset(direction);
+                if (!component.contains(neighbor)) {
+                    continue;
+                }
+                int previous = insidePower.getOrDefault(neighbor, 0);
+                if (output > previous) {
+                    insidePower.put(neighbor, output);
+                    queue.addLast(neighbor);
+                }
+            }
+        }
+
+        int startInside = insidePower.getOrDefault(pos, 0);
+        int finalPower = MathHelper.clamp(startInside - getPenalty(state), 0, 15);
+        return finalPower;
+    }
+
+    private static Set<BlockPos> collectComponent(WorldView world, BlockPos origin) {
+        Set<BlockPos> component = new HashSet<>();
+        Deque<BlockPos> stack = new ArrayDeque<>();
+        stack.push(origin);
+        component.add(origin);
+
+        while (!stack.isEmpty()) {
+            BlockPos current = stack.pop();
+            for (Direction direction : DIRECTIONS) {
+                BlockPos neighbor = current.offset(direction);
+                BlockState neighborState = world.getBlockState(neighbor);
+                if (isConductiveCopper(neighborState) && component.add(neighbor)) {
+                    stack.push(neighbor);
+                }
+            }
+        }
+
+        return component;
+    }
+
+    private static int getPenalty(BlockState state) {
+        Optional<Oxidizable.OxidationLevel> levelOptional = Oxidizable.getOxidationLevel(state);
+        if (levelOptional.isEmpty()) {
+            return 0;
+        }
+
+        return switch (levelOptional.get()) {
+            case UNAFFECTED -> 0;
+            case EXPOSED -> 1;
+            case WEATHERED -> 2;
+            case OXIDIZED -> 3;
+        };
+    }
+}

--- a/src/main/java/com/example/copperpower/CopperPowerMod.java
+++ b/src/main/java/com/example/copperpower/CopperPowerMod.java
@@ -1,0 +1,11 @@
+package com.example.copperpower;
+
+import net.fabricmc.api.ModInitializer;
+public class CopperPowerMod implements ModInitializer {
+    public static final String MOD_ID = "copperpower";
+
+    @Override
+    public void onInitialize() {
+        System.out.println("CopperPower loaded - copper blocks now conduct redstone!");
+    }
+}

--- a/src/main/java/com/example/copperpower/mixin/BlockMixin.java
+++ b/src/main/java/com/example/copperpower/mixin/BlockMixin.java
@@ -1,0 +1,36 @@
+package com.example.copperpower.mixin;
+
+import com.example.copperpower.CopperNetwork;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Block.class)
+public abstract class BlockMixin {
+    @Inject(method = "emitsRedstonePower", at = @At("HEAD"), cancellable = true)
+    private void copperpower$emitsRedstonePower(BlockState state, CallbackInfoReturnable<Boolean> cir) {
+        if (CopperNetwork.isConductiveCopper(state)) {
+            cir.setReturnValue(true);
+        }
+    }
+
+    @Inject(method = "getWeakRedstonePower", at = @At("HEAD"), cancellable = true)
+    private void copperpower$getWeakRedstonePower(BlockState state, BlockView world, BlockPos pos, Direction direction, CallbackInfoReturnable<Integer> cir) {
+        if (CopperNetwork.isConductiveCopper(state)) {
+            cir.setReturnValue(CopperNetwork.computePower(state, world, pos));
+        }
+    }
+
+    @Inject(method = "getStrongRedstonePower", at = @At("HEAD"), cancellable = true)
+    private void copperpower$getStrongRedstonePower(BlockState state, BlockView world, BlockPos pos, Direction direction, CallbackInfoReturnable<Integer> cir) {
+        if (CopperNetwork.isConductiveCopper(state)) {
+            cir.setReturnValue(CopperNetwork.computePower(state, world, pos));
+        }
+    }
+}

--- a/src/main/resources/copperpower.mixins.json
+++ b/src/main/resources/copperpower.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.example.copperpower.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "BlockMixin"
+  ],
+  "client": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "id": "copperpower",
+  "version": "1.0.0",
+  "name": "CopperPower",
+  "description": "Медные блоки передают редстоун-сигнал с учётом стадии окисления.",
+  "authors": [
+    "CopperPower Team"
+  ],
+  "license": "MIT",
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "com.example.copperpower.CopperPowerMod"
+    ]
+  },
+  "mixins": [
+    "copperpower.mixins.json"
+  ],
+  "depends": {
+    "fabricloader": ">=0.15.11",
+    "fabric-api": "*",
+    "minecraft": "1.20.1",
+    "java": ">=17"
+  }
+}

--- a/stubs/src/main/java/net/fabricmc/api/ModInitializer.java
+++ b/stubs/src/main/java/net/fabricmc/api/ModInitializer.java
@@ -1,0 +1,5 @@
+package net.fabricmc.api;
+
+public interface ModInitializer {
+    void onInitialize();
+}

--- a/stubs/src/main/java/net/minecraft/block/Block.java
+++ b/stubs/src/main/java/net/minecraft/block/Block.java
@@ -1,0 +1,19 @@
+package net.minecraft.block;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.BlockView;
+
+public class Block {
+    public boolean emitsRedstonePower(BlockState state) {
+        return false;
+    }
+
+    public int getWeakRedstonePower(BlockState state, BlockView world, BlockPos pos, Direction direction) {
+        return 0;
+    }
+
+    public int getStrongRedstonePower(BlockState state, BlockView world, BlockPos pos, Direction direction) {
+        return 0;
+    }
+}

--- a/stubs/src/main/java/net/minecraft/block/BlockState.java
+++ b/stubs/src/main/java/net/minecraft/block/BlockState.java
@@ -1,0 +1,9 @@
+package net.minecraft.block;
+
+import net.minecraft.registry.tag.TagKey;
+
+public class BlockState {
+    public boolean isIn(TagKey<Block> tag) {
+        return false;
+    }
+}

--- a/stubs/src/main/java/net/minecraft/block/Oxidizable.java
+++ b/stubs/src/main/java/net/minecraft/block/Oxidizable.java
@@ -1,0 +1,16 @@
+package net.minecraft.block;
+
+import java.util.Optional;
+
+public interface Oxidizable {
+    static Optional<OxidationLevel> getOxidationLevel(BlockState state) {
+        return Optional.empty();
+    }
+
+    enum OxidationLevel {
+        UNAFFECTED,
+        EXPOSED,
+        WEATHERED,
+        OXIDIZED
+    }
+}

--- a/stubs/src/main/java/net/minecraft/registry/tag/BlockTags.java
+++ b/stubs/src/main/java/net/minecraft/registry/tag/BlockTags.java
@@ -1,0 +1,10 @@
+package net.minecraft.registry.tag;
+
+import net.minecraft.block.Block;
+
+public final class BlockTags {
+    public static final TagKey<Block> COPPER_BLOCKS = TagKey.of();
+
+    private BlockTags() {
+    }
+}

--- a/stubs/src/main/java/net/minecraft/registry/tag/TagKey.java
+++ b/stubs/src/main/java/net/minecraft/registry/tag/TagKey.java
@@ -1,0 +1,10 @@
+package net.minecraft.registry.tag;
+
+public final class TagKey<T> {
+    private TagKey() {
+    }
+
+    public static <T> TagKey<T> of() {
+        return new TagKey<>();
+    }
+}

--- a/stubs/src/main/java/net/minecraft/util/math/BlockPos.java
+++ b/stubs/src/main/java/net/minecraft/util/math/BlockPos.java
@@ -1,0 +1,7 @@
+package net.minecraft.util.math;
+
+public class BlockPos {
+    public BlockPos offset(Direction direction) {
+        return this;
+    }
+}

--- a/stubs/src/main/java/net/minecraft/util/math/Direction.java
+++ b/stubs/src/main/java/net/minecraft/util/math/Direction.java
@@ -1,0 +1,25 @@
+package net.minecraft.util.math;
+
+public enum Direction {
+    DOWN,
+    UP,
+    NORTH,
+    SOUTH,
+    WEST,
+    EAST;
+
+    public static Direction[] valuesCached() {
+        return values();
+    }
+
+    public Direction getOpposite() {
+        return switch (this) {
+            case DOWN -> UP;
+            case UP -> DOWN;
+            case NORTH -> SOUTH;
+            case SOUTH -> NORTH;
+            case WEST -> EAST;
+            case EAST -> WEST;
+        };
+    }
+}

--- a/stubs/src/main/java/net/minecraft/util/math/MathHelper.java
+++ b/stubs/src/main/java/net/minecraft/util/math/MathHelper.java
@@ -1,0 +1,16 @@
+package net.minecraft.util.math;
+
+public final class MathHelper {
+    private MathHelper() {
+    }
+
+    public static int clamp(int value, int min, int max) {
+        if (value < min) {
+            return min;
+        }
+        if (value > max) {
+            return max;
+        }
+        return value;
+    }
+}

--- a/stubs/src/main/java/net/minecraft/world/BlockView.java
+++ b/stubs/src/main/java/net/minecraft/world/BlockView.java
@@ -1,0 +1,8 @@
+package net.minecraft.world;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+
+public interface BlockView {
+    BlockState getBlockState(BlockPos pos);
+}

--- a/stubs/src/main/java/net/minecraft/world/WorldAccess.java
+++ b/stubs/src/main/java/net/minecraft/world/WorldAccess.java
@@ -1,0 +1,8 @@
+package net.minecraft.world;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+public interface WorldAccess extends WorldView {
+    int getEmittedRedstonePower(BlockPos pos, Direction direction);
+}

--- a/stubs/src/main/java/net/minecraft/world/WorldView.java
+++ b/stubs/src/main/java/net/minecraft/world/WorldView.java
@@ -1,0 +1,4 @@
+package net.minecraft.world;
+
+public interface WorldView extends BlockView {
+}

--- a/stubs/src/main/java/org/spongepowered/asm/mixin/Mixin.java
+++ b/stubs/src/main/java/org/spongepowered/asm/mixin/Mixin.java
@@ -1,0 +1,12 @@
+package org.spongepowered.asm.mixin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Mixin {
+    Class<?>[] value();
+}

--- a/stubs/src/main/java/org/spongepowered/asm/mixin/injection/At.java
+++ b/stubs/src/main/java/org/spongepowered/asm/mixin/injection/At.java
@@ -1,0 +1,12 @@
+package org.spongepowered.asm.mixin.injection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface At {
+    String value();
+}

--- a/stubs/src/main/java/org/spongepowered/asm/mixin/injection/Inject.java
+++ b/stubs/src/main/java/org/spongepowered/asm/mixin/injection/Inject.java
@@ -1,0 +1,14 @@
+package org.spongepowered.asm.mixin.injection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Inject {
+    String method();
+    At at();
+    boolean cancellable() default false;
+}

--- a/stubs/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInfoReturnable.java
+++ b/stubs/src/main/java/org/spongepowered/asm/mixin/injection/callback/CallbackInfoReturnable.java
@@ -1,0 +1,6 @@
+package org.spongepowered.asm.mixin.injection.callback;
+
+public class CallbackInfoReturnable<T> {
+    public void setReturnValue(T value) {
+    }
+}


### PR DESCRIPTION
## Summary
- add Fabric Gradle project configuration and metadata for the CopperPower mod
- implement copper network redstone propagation logic and mixin hooks for copper blocks
- include compilation stubs so the project can be built without external dependencies in this environment

## Testing
- javac -source 17 -target 17 -cp build/stubs/stubs.jar -d build/classes $(find src/main/java -name '*.java')
- jar cfm build/libs/CopperPower-1.0.0.jar build/MANIFEST.MF -C build/classes . -C src/main/resources .


------
https://chatgpt.com/codex/tasks/task_b_68d6cee62994832ab66a0b2a7483ee9b